### PR TITLE
Rename _render to _updateLatex in Pixi widget so it isn't called every frame

### DIFF
--- a/src/renderers/pixijs/Widget.js
+++ b/src/renderers/pixijs/Widget.js
@@ -28,7 +28,7 @@ export default class PixiJS extends PIXI.Container {
     this._classes = {}
 
     this._options = options
-    this._render()
+    this._updateLatex()
   }
 
   /**
@@ -79,7 +79,7 @@ export default class PixiJS extends PIXI.Container {
   set latex (latex = '') {
     this.removeChildren()
     this._latex = latex
-    this._render()
+    this._updateLatex()
   }
 
   /**
@@ -126,7 +126,7 @@ export default class PixiJS extends PIXI.Container {
    * -------------------------------------------
    */
 
-  _render () {
+   _updateLatex () {
     this._eventEmitter.emit(EVENTS.PRE_RENDER)
     const nodeBuilder = new VirtualNodeBuilder(this._latex, this._options)
     const nodeData = nodeBuilder.build()


### PR DESCRIPTION
Trying to use this in a pixi.js animation I found it was *extremely* slow. Problem seems to be that `PixiJS._render` is called by pixi.js every frame. But we actually only want to call it when the math changes, which is relatively unusual. This patch fixes the performance trouble.